### PR TITLE
Add `assert_de_tokens_error2` that shows deserialized value in the message

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -128,7 +128,11 @@ where
 {
     let mut ser = Serializer::new(tokens);
     match value.serialize(&mut ser) {
-        Ok(()) => panic!("value serialized successfully"),
+        Ok(()) => assert_eq!(
+            None,
+            Some(error),
+            "value serialized successfully, but error expected (right)"
+        ),
         Err(e) => assert_eq!(e, *error),
     }
 

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -237,3 +237,50 @@ where
         panic!("{} remaining tokens", de.remaining());
     }
 }
+
+/// Asserts that the given `tokens` yield `error` when deserializing.
+///
+/// The same, as [`assert_de_tokens_error`], but produces an error message which
+/// contains result of deserialization in case if tokens deserialized to something.
+///
+/// ```
+/// # use serde_derive::{Deserialize, Serialize};
+/// # use serde_test::{assert_de_tokens_error2, Token};
+/// #
+/// #[derive(Serialize, Deserialize, PartialEq, Debug)]
+/// #[serde(deny_unknown_fields)]
+/// struct S {
+///     a: u8,
+///     b: u8,
+/// }
+///
+/// assert_de_tokens_error2::<S>(
+///     &[
+///         Token::Struct { name: "S", len: 2 },
+///         Token::Str("x"),
+///     ],
+///     "unknown field `x`, expected `a` or `b`",
+/// );
+/// ```
+#[cfg_attr(not(no_track_caller), track_caller)]
+pub fn assert_de_tokens_error2<'de, T>(tokens: &'de [Token], error: &str)
+where
+    T: Deserialize<'de> + Debug,
+{
+    let mut de = Deserializer::new(tokens);
+    match T::deserialize(&mut de) {
+        Ok(x) => assert_eq!(
+            error,
+            format!("{:?}", x),
+            "expected error (left) but tokens deserialized successfully (right)"
+        ),
+        Err(e) => assert_eq!(e, *error),
+    }
+
+    // There may be one token left if a peek caused the error
+    de.next_token_opt();
+
+    if de.remaining() > 0 {
+        panic!("{} remaining tokens", de.remaining());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ mod ser;
 mod token;
 
 pub use crate::assert::{
-    assert_de_tokens, assert_de_tokens_error, assert_ser_tokens, assert_ser_tokens_error,
-    assert_tokens,
+    assert_de_tokens, assert_de_tokens_error, assert_de_tokens_error2, assert_ser_tokens,
+    assert_ser_tokens_error, assert_tokens,
 };
 pub use crate::configure::{Compact, Configure, Readable};
 pub use crate::token::Token;


### PR DESCRIPTION
Continuation of https://github.com/serde-rs/serde/pull/2460 in new repo.

Instead of changing `assert_de_tokens_error` I've added a new function which does the same, but outputs deserialized value in case of failure