### PR TITLE
feat: make `de` and `ser` modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,10 @@
 
 mod assert;
 mod configure;
-mod de;
+pub mod de;
+pub mod ser;
+
 mod error;
-mod ser;
 mod token;
 
 pub use crate::assert::{


### PR DESCRIPTION
PR makes the `de` and `ser` modules public, specifically so that the `Deserializer` and `Serializer` structs can be used directly in edge cases where the existing `assert_(*_)tokens` utilities do not meet the requirement.