### PR TITLE
Add support for `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta, nightly, 1.56.0]
+        features: [--no-default-features, ""]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-      - run: cargo build
-      - run: cargo test --features serde/derive,serde/rc
+      - run: cargo build ${{matrix.features}}
+      - run: cargo test ${{matrix.features}} --features serde/derive,serde/rc
       - uses: actions/upload-artifact@v4
         if: matrix.rust == 'nightly' && always()
         with:
@@ -38,12 +39,16 @@ jobs:
   minimal:
     name: Minimal versions
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features: [--no-default-features, ""]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo generate-lockfile -Z minimal-versions
-      - run: cargo check --locked
+      - run: cargo check --locked ${{matrix.features}}
 
   doc:
     name: Documentation
@@ -61,11 +66,15 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        features: [--no-default-features, ""]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@clippy
-      - run: cargo clippy -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy ${{matrix.features}} -- -Dclippy::all -Dclippy::pedantic
 
   outdated:
     name: Outdated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/serde-rs/test"
 rust-version = "1.56"
 
+[features]
+default = ["std"]
+std = ["serde/std"]
+
 [dependencies]
-serde = "1.0.69"
+serde = { version = "1.0.70", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-serde = { version = "1", features = ["rc"] }
+serde = { version = "1", default-features = false, features = ["rc"] }
 serde_derive = "1"
 
 [lib]

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,8 +1,8 @@
 use crate::de::Deserializer;
 use crate::ser::Serializer;
 use crate::token::Token;
+use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// Runs both `assert_ser_tokens` and `assert_de_tokens`.
 ///
@@ -83,6 +83,10 @@ where
 /// `error`.
 ///
 /// ```
+/// # #[cfg(not(feature = "std"))]
+/// # fn main() {}
+/// # #[cfg(feature = "std")]
+/// # fn main() {
 /// use serde_derive::Serialize;
 /// use serde_test::{assert_ser_tokens_error, Token};
 /// use std::sync::{Arc, Mutex};
@@ -120,6 +124,8 @@ where
 ///     let error = "lock poison error while serializing";
 ///     assert_ser_tokens_error(&example, expected, error);
 /// }
+/// # main();
+/// # }
 /// ```
 #[track_caller]
 pub fn assert_ser_tokens_error<T>(value: &T, tokens: &[Token], error: &str)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,3 +1,6 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
 use serde::de::{
     Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error, MapAccess, SeqAccess,
     VariantAccess, Visitor,
@@ -6,7 +9,6 @@ use serde::ser::{
     Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant, Serializer,
 };
-use std::fmt::{self, Display};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Readable<T: ?Sized>(T);

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,5 +1,8 @@
 use crate::error::Error;
 use crate::token::Token;
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::ToString;
 use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
+use alloc::string::{String, ToString};
+use core::fmt::{self, Display};
 use serde::{de, ser};
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt::{self, Display};
 
 #[derive(Clone, Debug)]
 pub struct Error {
@@ -29,6 +31,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
         &self.msg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,9 @@ extern crate alloc;
 
 mod assert;
 mod configure;
-mod de;
-mod error;
-mod ser;
+pub mod de;
+pub mod error;
+pub mod ser;
 mod token;
 
 pub use crate::assert::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@
     clippy::module_name_repetitions,
     clippy::too_many_lines
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod assert;
 mod configure;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
 use crate::token::Token;
+use alloc::format;
+use alloc::string::String;
 use serde::ser::{self, Serialize};
 
 /// A `Serializer` that ensures that a value serializes to a given list of
@@ -45,7 +47,7 @@ macro_rules! assert_next_token {
     ($ser:expr, $actual:ident { $($k:ident),* }) => {{
         let compare = ($($k,)*);
         let field_format = || {
-            use std::fmt::Write;
+            use core::fmt::Write;
             let mut buffer = String::new();
             $(
                 write!(&mut buffer, concat!(stringify!($k), ": {:?}, "), $k).unwrap();

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Token {


### PR DESCRIPTION
This adds support to `no_std` environments by using `default-features = false` and adding `features = ["alloc"]` to the `serde` dependency. To preserve the MSRV, I added an `std` crate feature and enabled it by default, as unfortunately the `Error` trait hadn't been moved to `core` at v1.56 yet. So I'm unsure if there are any guidelines if this counts as a breaking change, but I believe not.

I also adjusted the CI to test without default features and with. Let me know if you want me to add that matrix to `cargo doc` as well.